### PR TITLE
Add Elo-based CS2 match predictor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README
+++ b/README
@@ -1,1 +1,26 @@
+# CS2 Match Predictor
 
+This repository contains a simple command line application for predicting Counter-Strike 2 match outcomes using an Elo rating system.
+
+## Requirements
+
+- Python 3.8+
+
+## Usage
+
+1. Install dependencies (none besides Python standard library).
+2. Run the predictor with the provided sample dataset:
+
+```bash
+python -m cs2_match_predictor.main sample_matches.csv FaZe G2
+```
+
+The script will output the probability of the first team beating the second team based on Elo ratings calculated from the dataset.
+
+You can add more historical match results to `sample_matches.csv` or provide your own CSV file with the columns:
+
+```
+team1,team2,team1_score,team2_score
+```
+
+Update the dataset with recent matches to improve predictions.

--- a/cs2_match_predictor/elo.py
+++ b/cs2_match_predictor/elo.py
@@ -1,0 +1,43 @@
+# Simple Elo rating system for CS2 match predictions
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+K_FACTOR = 32
+START_RATING = 1500
+
+@dataclass
+class MatchResult:
+    team1: str
+    team2: str
+    winner: str  # name of the winning team
+
+def expected_score(rating_a: float, rating_b: float) -> float:
+    """Compute expected score for team A."""
+    return 1 / (1 + 10 ** ((rating_b - rating_a) / 400))
+
+def update_ratings(ratings: Dict[str, float], match: MatchResult) -> None:
+    """Update Elo ratings based on a single match result."""
+    r1 = ratings.get(match.team1, START_RATING)
+    r2 = ratings.get(match.team2, START_RATING)
+
+    expected1 = expected_score(r1, r2)
+    expected2 = expected_score(r2, r1)
+
+    score1 = 1 if match.winner == match.team1 else 0
+    score2 = 1 if match.winner == match.team2 else 0
+
+    ratings[match.team1] = r1 + K_FACTOR * (score1 - expected1)
+    ratings[match.team2] = r2 + K_FACTOR * (score2 - expected2)
+
+def build_ratings(matches: Iterable[MatchResult]) -> Dict[str, float]:
+    """Build ratings from a list of match results."""
+    ratings: Dict[str, float] = {}
+    for match in matches:
+        update_ratings(ratings, match)
+    return ratings
+
+def predict(ratings: Dict[str, float], team1: str, team2: str) -> float:
+    """Predict probability that team1 beats team2."""
+    r1 = ratings.get(team1, START_RATING)
+    r2 = ratings.get(team2, START_RATING)
+    return expected_score(r1, r2)

--- a/cs2_match_predictor/main.py
+++ b/cs2_match_predictor/main.py
@@ -1,0 +1,35 @@
+import csv
+import argparse
+from .elo import MatchResult, build_ratings, predict
+
+
+def load_matches(csv_path):
+    matches = []
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            winner = row["team1"] if int(row["team1_score"]) > int(row["team2_score"]) else row["team2"]
+            matches.append(
+                MatchResult(
+                    team1=row["team1"],
+                    team2=row["team2"],
+                    winner=winner,
+                )
+            )
+    return matches
+
+
+def cli():
+    parser = argparse.ArgumentParser(description="Predict CS2 match outcomes using Elo ratings")
+    parser.add_argument("dataset", help="Path to CSV dataset of past matches")
+    parser.add_argument("team1", help="Name of the first team")
+    parser.add_argument("team2", help="Name of the second team")
+    args = parser.parse_args()
+
+    matches = load_matches(args.dataset)
+    ratings = build_ratings(matches)
+    prob = predict(ratings, args.team1, args.team2)
+    print(f"Probability that {args.team1} beats {args.team2}: {prob:.2%}")
+
+if __name__ == "__main__":
+    cli()

--- a/sample_matches.csv
+++ b/sample_matches.csv
@@ -1,0 +1,11 @@
+team1,team2,team1_score,team2_score
+FaZe,G2,16,12
+NatusVincere,FaZe,11,16
+Astralis,G2,16,9
+TeamSpirit,Astralis,16,14
+FaZe,TeamSpirit,13,16
+NatusVincere,G2,16,10
+TeamSpirit,NatusVincere,15,19
+FaZe,Astralis,16,8
+Astralis,NatusVincere,14,16
+G2,TeamSpirit,9,16


### PR DESCRIPTION
## Summary
- implement simple Elo algorithm for match predictions
- add CLI interface in `main.py`
- include sample dataset
- document usage in README
- ignore Python cache files

## Testing
- `python -m cs2_match_predictor.main sample_matches.csv FaZe G2`